### PR TITLE
fix dependency and installation procedure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # opr_ros
-ROS package for CIT Open Platform Robot GankenKun. Tested on ROS Kinetic.
+ROS package for CIT Open Platform Robot GankenKun. Tested on ROS Melodic.
 
 ## Installation
 1. Install ros
@@ -19,12 +19,12 @@ $ git clone https://github.com/citbrains/opr_ros.git
 $ wstool init .
 $ wstool merge opr_ros/opr_ros.rosinstall
 $ wstool update
-$ rosdep install --from-paths opr_ros --ignore-src --rosdistro kinetic
+$ rosdep install --from-paths . --ignore-src --rosdistro melodic -r -y
 ```
 4. build and source
 ```
 $ cd ~/catkin_ws
-$ catkin build opr_ros
+$ catkin build 
 $ catkin source
 ```
 

--- a/hajime_walk_ros/package.xml
+++ b/hajime_walk_ros/package.xml
@@ -8,17 +8,9 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>roscpp</build_depend>
-  <build_depend>std_msgs</build_depend>
-  <build_depend>sensor_msgs</build_depend>
-  <build_depend>opr_msgs</build_depend>
-
-  <build_export_depend>roscpp</build_export_depend>
-  <build_export_depend>std_msgs</build_export_depend>
-
-  <exec_depend>roscpp</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
-  <exec_depend>sensor_msgs</exec_depend>
-  <exec_depend>opr_msgs</exec_depend>
+  <depend>roscpp</depend>
+  <depend>std_msgs</depend>
+  <depend>sensor_msgs</depend>
+  <depend>opr_msgs</depend>
 
 </package>

--- a/opr_description/package.xml
+++ b/opr_description/package.xml
@@ -7,8 +7,6 @@
   <license>Apache License, Version 2.0</license>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>xacro</build_depend>
-  <build_export_depend>xacro</build_export_depend>
-  <exec_depend>xacro</exec_depend>
+  <depend>xacro</depend>
 
 </package>

--- a/opr_gazebo/package.xml
+++ b/opr_gazebo/package.xml
@@ -8,26 +8,12 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>roscpp</build_depend>
-  <build_depend>geometry_msgs</build_depend>
-  <build_depend>opr_msgs</build_depend>
-  <build_depend>gazebo_ros</build_depend>
-  <build_depend>gazebo_ros_control</build_depend>
-  <build_depend>gazebo_msgs</build_depend>
-
-  <build_export_depend>roscpp</build_export_depend>
-  <build_export_depend>geometry_msgs</build_export_depend>
-  <build_export_depend>opr_msgs</build_export_depend>
-  <build_export_depend>gazebo_ros</build_export_depend>
-  <build_export_depend>gazebo_ros_control</build_export_depend>
-  <build_export_depend>gazebo_msgs</build_export_depend>
-
-  <exec_depend>roscpp</exec_depend>
-  <exec_depend>geometry_msgs</exec_depend>
-  <exec_depend>opr_msgs</exec_depend>
-  <exec_depend>gazebo_ros</exec_depend>
-  <exec_depend>gazebo_ros_control</exec_depend>
-  <exec_depend>gazebo_msgs</exec_depend>
+  <depend>roscpp</depend>
+  <depend>geometry_msgs</depend>
+  <depend>opr_msgs</depend>
+  <depend>gazebo_ros</depend>
+  <depend>gazebo_ros_control</depend>
+  <depend>gazebo_msgs</depend>
 
   <export>
     <gazebo_ros gazebo_media_path="${prefix}/worlds" />

--- a/opr_kondo_driver/package.xml
+++ b/opr_kondo_driver/package.xml
@@ -7,19 +7,17 @@
   <license>Apache License, Version 2.0</license>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>hardware_interface</build_depend>
-  <build_depend>joint_state_controller</build_depend>
+
+  <depend>libusb-dev</depend>
+  <depend>libftdi-dev</depend>
+  <depend>hardware_interface</depend>
+  <depend>roscpp</depend>
+  <depend>joint_state_controller</depend>
+  <depend>position_controllers</depend>
+
   <build_depend>message_generation</build_depend>
-  <build_depend>position_controllers</build_depend>
-  <build_depend>roscpp</build_depend>
-  <build_export_depend>hardware_interface</build_export_depend>
-  <build_export_depend>joint_state_controller</build_export_depend>
-  <build_export_depend>roscpp</build_export_depend>
+
   <exec_depend>controller_manager</exec_depend>
-  <exec_depend>hardware_interface</exec_depend>
-  <exec_depend>joint_state_controller</exec_depend>
   <exec_depend>message_runtime</exec_depend>
-  <exec_depend>position_controllers</exec_depend>
-  <exec_depend>roscpp</exec_depend>
 
 </package>

--- a/opr_ros/CMakeLists.txt
+++ b/opr_ros/CMakeLists.txt
@@ -1,4 +1,4 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(opr_ros)
 find_package(catkin REQUIRED)
-catkin_package()
+catkin_metapackage()

--- a/opr_ros/package.xml
+++ b/opr_ros/package.xml
@@ -7,12 +7,15 @@
   <license>Apache License, Version 2.0</license>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>hajime_walk_ros</build_depend>
-  <build_depend>opr_bringup</build_depend>
-  <build_depend>opr_description</build_depend>
-  <build_depend>opr_gazebo</build_depend>
-  <build_depend>opr_kondo_driver</build_depend>
-  <build_depend>opr_msgs</build_depend>
-  <build_depend>opr_ros_control</build_depend>
+  <exec_depend>hajime_walk_ros</exec_depend>
+  <exec_depend>opr_bringup</exec_depend>
+  <exec_depend>opr_description</exec_depend>
+  <exec_depend>opr_gazebo</exec_depend>
+  <exec_depend>opr_kondo_driver</exec_depend>
+  <exec_depend>opr_msgs</exec_depend>
+  <exec_depend>opr_ros_control</exec_depend>
 
+  <export>
+    <metapackage/>
+  </export>
 </package>


### PR DESCRIPTION
* インストール依存関係周りを修正
* READMEのインストール手順を修正
* #7 を対応
  * package.xmlにlibusb-dev, libftdi-devを追加したためrosdepを呼び出すと勝手にインストールするはず
* melodicに動作確認

@SatoshiShimada 時間があれば確認してみてください

問題無ければ適当なタイミングでマージします